### PR TITLE
doc/readme - update test case path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Alternatively, you can invoke ExpoSE directly via the `expoSE` command line inte
 Example:
 
 ```sh
-$ expoSE ./tests/integers/infoflow
+$ expoSE ./tests/numbers/infoflow
 ```
 
 Valid Options:


### PR DESCRIPTION
seems the directory was renamed from `integers` to `numbers` at some point